### PR TITLE
Fixed the crash:

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationMapRoute.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationMapRoute.java
@@ -492,14 +492,16 @@ public class NavigationMapRoute implements MapView.OnDidFinishLoadingStyleListen
     private void updateArrowShaftWith(List<Point> points) {
         LineString shaft = LineString.fromLngLats(points);
         arrowShaftGeoJsonFeature = Feature.fromGeometry(shaft);
-        arrowShaftGeoJsonSource.setGeoJson(arrowShaftGeoJsonFeature);
+        if(arrowShaftGeoJsonSource != null)
+            arrowShaftGeoJsonSource.setGeoJson(arrowShaftGeoJsonFeature);
     }
 
     private void updateArrowHeadWith(List<Point> points) {
         double azimuth = TurfMeasurement.bearing(points.get(points.size() - 2), points.get(points.size() - 1));
         arrowHeadGeoJsonFeature = Feature.fromGeometry(points.get(points.size() - 1));
         arrowHeadGeoJsonFeature.addNumberProperty(ARROW_BEARING, (float) MathUtils.wrap(azimuth, 0, MAX_DEGREES));
-        arrowHeadGeoJsonSource.setGeoJson(arrowHeadGeoJsonFeature);
+        if(arrowHeadGeoJsonSource != null)
+            arrowHeadGeoJsonSource.setGeoJson(arrowHeadGeoJsonFeature);
     }
 
     private void initializeUpcomingManeuverArrow() {


### PR DESCRIPTION
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'void com.mapbox.mapboxsdk.style.sources.GeoJsonSource.setGeoJson(com.mapbox.geojson.Feature)' on a null object reference
       at com.mapbox.services.android.navigation.v5.navigation.NavigationMapRoute.updateArrowShaftWith(NavigationMapRoute.java:495)
       at com.mapbox.services.android.navigation.v5.navigation.NavigationMapRoute.addUpcomingManeuverArrow(NavigationMapRoute.java:355)
       at com.mapbox.services.android.navigation.v5.route.MapRouteProgressChangeListener.onProgressChange(MapRouteProgressChangeListener.java:26)
       at com.mapbox.services.android.navigation.v5.navigation.NavigationEventDispatcher.onProgressChange(NavigationEventDispatcher.java:145)
       at com.mapbox.services.android.navigation.v5.navigation.RouteProcessorThreadListener.onNewRouteProgress(RouteProcessorThreadListener.java:34)
       at com.mapbox.services.android.navigation.v5.navigation.RouteProcessorHandlerCallback$1.run(RouteProcessorHandlerCallback.java:97)
       at android.os.Handler.handleCallback(Handler.java:938)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loop(Looper.java:246)
       at android.app.ActivityThread.main(ActivityThread.java:8633)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:602)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1130)

this could accure when the source isn't loaded yet.